### PR TITLE
Support `project-prompt-project-name` out of the box

### DIFF
--- a/auto-tab-groups-project.el
+++ b/auto-tab-groups-project.el
@@ -30,7 +30,7 @@
     (if (file-remote-p project-root) ?T ?P)))
 
 (defvar auto-tab-groups-project--create-commands
-  '((project-prompt-project-dir project-switch-to-buffer) . auto-tab-groups-group-name-project))
+  '((project-prompt-project-dir project-prompt-project-name project-switch-to-buffer) . auto-tab-groups-group-name-project))
 
 (defvar auto-tab-groups-project--close-commands
   '(project-kill-buffers . auto-tab-groups-group-name-project))


### PR DESCRIPTION
Hi Marcel!

This is just a quick quality-of-life improvement for folks who have set  `project-prompter` to `project-prompt-project-name` (vs. the default `project-prompt-project-dir`), like me. 😅

It's the _other_ one of two prompting methods that Emacs supports natively, and this PR just adds support for it in your awesome package out of the box.

Best regards,
Fritz